### PR TITLE
Add docker container with entrypoint for talker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+FROM ubuntu:16.04
+
+#--------------------
+# General setup
+#--------------------
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# setup keys
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+
+RUN apt-get update
+RUN apt install -y cmake git python3 python3-pip python3-empy g++-multilib
+RUN pip3 install vcstool
+
+#--------------------
+# Install cross-compiler
+# TODO: this will need to be board dependendant.
+#--------------------
+RUN apt-get install -y software-properties-common python-software-properties
+RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa
+RUN apt-get update
+RUN apt install -y gcc-arm-embedded
+RUN apt install -y wget
+
+#--------------------
+# Sources
+#--------------------
+WORKDIR /root
+RUN mkdir -p /root/ros2_riot_ws/src
+RUN cd /root/ros2_riot_ws && wget https://raw.githubusercontent.com/erlerobot/riot-ros2/base/riot-ros2.repos
+RUN cd /root/ros2_riot_ws && wget https://raw.githubusercontent.com/erlerobot/riot-ros2/base/ament2riot.cmake
+RUN cd /root/ros2_riot_ws && vcs import src < riot-ros2.repos
+# AMENT_IGNORE test_msgs package
+RUN cd /root/ros2_riot_ws && touch src/ros2/rcl_interfaces/test_msgs/AMENT_IGNORE
+
+# #--------------------
+# # Tooling and compiling (split but altogether)
+# #--------------------
+# RUN mkdir -p /root/ros2_riot_ws/tools/src
+# RUN cd /root/ros2_riot_ws/tools && wget https://raw.githubusercontent.com/erlerobot/riot-ros2/base/riot-ros2-tools.repos
+# RUN cd /root/ros2_riot_ws/tools && vcs import src < riot-ros2-tools.repos
+# RUN pip3 install pyparsing
+# RUN cd /root/ros2_riot_ws/tools && ./src/ament/ament_tools/scripts/ament.py build --symlink-install
+# RUN source /root/ros2_riot_ws/tools/install/setup.bash
+# RUN cd /root/ros2_riot_ws && ament build --symlink-install --force-cmake-configure --cmake-args -DCMAKE_TOOLCHAIN_FILE=`pwd`/ament2riot.cmake
+
+#--------------------
+# Tooling
+#--------------------
+# RUN mkdir -p /root/ros2_riot_ws/tools/src
+RUN cd /root/ros2_riot_ws && wget https://raw.githubusercontent.com/erlerobot/riot-ros2/base/riot-ros2-tools.repos
+RUN cd /root/ros2_riot_ws && vcs import src < riot-ros2-tools.repos
+RUN pip3 install pyparsing
+
+#--------------------
+# Cross-compiling (phase 1)
+#--------------------
+# Phase 1: cross-compile everything through ament
+RUN cd /root/ros2_riot_ws && ./src/ament/ament_tools/scripts/ament.py build --symlink-install --force-cmake-configure --cmake-args -DCMAKE_TOOLCHAIN_FILE=`pwd`/ament2riot.cmake
+
+#--------------------
+# Compiling for platform (phase 2)
+#    only preparing the env.
+#--------------------
+# Phase 2: compiling each application for it's target microcontroller with RIOT's Makefiles.
+# setup the tap interface
+RUN ls
+COPY patches /root
+RUN patch /root/ros2_riot_ws/install/RIOT/dist/tools/tapsetup/tapsetup /root/sudo-tapsetup.patch
+RUN patch -R /root/ros2_riot_ws/install/RIOT/dist/tools/tapsetup/tapsetup /root/docker-tapsetup.patch
+
+RUN apt-get install -y unzip bsdmainutils
+# Configure exemplary git credentials to run native examples
+RUN git config --global user.email "you@example.com"
+RUN git config --global user.name "micro-ROS"
+
+
+#--------------------
+# Entry point
+#--------------------
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM ubuntu:16.04
 #--------------------
 # General setup
 #--------------------
+# setup download url
+ENV DOWNLOAD_URL https://raw.githubusercontent.com/astralien3000/riot-ros2/master
+
 # setup environment
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
@@ -32,8 +35,8 @@ RUN apt install -y wget
 #--------------------
 WORKDIR /root
 RUN mkdir -p /root/ros2_riot_ws/src
-RUN cd /root/ros2_riot_ws && wget https://raw.githubusercontent.com/erlerobot/riot-ros2/base/riot-ros2.repos
-RUN cd /root/ros2_riot_ws && wget https://raw.githubusercontent.com/erlerobot/riot-ros2/base/ament2riot.cmake
+RUN cd /root/ros2_riot_ws && wget ${DOWNLOAD_URL}/riot-ros2.repos
+RUN cd /root/ros2_riot_ws && wget ${DOWNLOAD_URL}/ament2riot.cmake
 RUN cd /root/ros2_riot_ws && vcs import src < riot-ros2.repos
 # AMENT_IGNORE test_msgs package
 RUN cd /root/ros2_riot_ws && touch src/ros2/rcl_interfaces/test_msgs/AMENT_IGNORE
@@ -42,7 +45,7 @@ RUN cd /root/ros2_riot_ws && touch src/ros2/rcl_interfaces/test_msgs/AMENT_IGNOR
 # # Tooling and compiling (split but altogether)
 # #--------------------
 # RUN mkdir -p /root/ros2_riot_ws/tools/src
-# RUN cd /root/ros2_riot_ws/tools && wget https://raw.githubusercontent.com/erlerobot/riot-ros2/base/riot-ros2-tools.repos
+# RUN cd /root/ros2_riot_ws/tools && wget ${DOWNLOAD_URL}/riot-ros2-tools.repos
 # RUN cd /root/ros2_riot_ws/tools && vcs import src < riot-ros2-tools.repos
 # RUN pip3 install pyparsing
 # RUN cd /root/ros2_riot_ws/tools && ./src/ament/ament_tools/scripts/ament.py build --symlink-install
@@ -53,7 +56,7 @@ RUN cd /root/ros2_riot_ws && touch src/ros2/rcl_interfaces/test_msgs/AMENT_IGNOR
 # Tooling
 #--------------------
 # RUN mkdir -p /root/ros2_riot_ws/tools/src
-RUN cd /root/ros2_riot_ws && wget https://raw.githubusercontent.com/erlerobot/riot-ros2/base/riot-ros2-tools.repos
+RUN cd /root/ros2_riot_ws && wget ${DOWNLOAD_URL}/riot-ros2-tools.repos
 RUN cd /root/ros2_riot_ws && vcs import src < riot-ros2-tools.repos
 RUN pip3 install pyparsing
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Create interaces
+export USER=micro-ros && /root/ros2_riot_ws/install/RIOT/dist/tools/tapsetup/tapsetup
+# Compile and run a native talker
+cd /root/ros2_riot_ws/install/talker_c && make PORT=tap0 all term
+
+exec "$@"

--- a/patches/docker-tapsetup.patch
+++ b/patches/docker-tapsetup.patch
@@ -1,0 +1,5 @@
+104,105c104
+<              #ip tuntap add dev ${TAPNAME}${N} mode tap user ${USER} || exit 1
+< 	     ip tuntap add dev ${TAPNAME}${N} mode tap || exit 1
+---
+>              ip tuntap add dev ${TAPNAME}${N} mode tap user ${USER} || exit 1

--- a/patches/sudo-tapsetup.patch
+++ b/patches/sudo-tapsetup.patch
@@ -1,0 +1,86 @@
+38,39c38,39
+<             sudo kldload if_bridge
+<             sudo ifconfig ${BRNAME} create || exit 1 ;;
+---
+>              kldload if_bridge
+>              ifconfig ${BRNAME} create || exit 1 ;;
+41c41
+<             sudo ip link add name ${BRNAME} type bridge || exit 1
+---
+>              ip link add name ${BRNAME} type bridge || exit 1
+43c43
+<                 sudo -s sh -c "echo 1  > /proc/sys/net/ipv6/conf/${BRNAME}/disable_ipv6" || exit 1
+---
+>                  -s sh -c "echo 1  > /proc/sys/net/ipv6/conf/${BRNAME}/disable_ipv6" || exit 1
+46c46
+<             sudo ifconfig ${BRNAME} create || exit 1 ;;
+---
+>              ifconfig ${BRNAME} create || exit 1 ;;
+55c55
+<             sudo ifconfig ${BRNAME} up || exit 1 ;;
+---
+>              ifconfig ${BRNAME} up || exit 1 ;;
+57c57
+<             sudo ip link set ${BRNAME} up || exit 1 ;;
+---
+>              ip link set ${BRNAME} up || exit 1 ;;
+68,70c68,70
+<             sudo sysctl net.link.tap.user_open=0
+<             sudo kldunload if_tap || exit 1
+<             sudo kldunload if_bridge || exit 1 ;;
+---
+>              sysctl net.link.tap.user_open=0
+>              kldunload if_tap || exit 1
+>              kldunload if_bridge || exit 1 ;;
+73c73
+<                 sudo ip link delete "${IF}"
+---
+>                  ip link delete "${IF}"
+76c76
+<             sudo ip link delete ${BRNAME} || exit 1 ;;
+---
+>              ip link delete ${BRNAME} || exit 1 ;;
+78c78
+<             sudo ifconfig ${BRNAME} destroy || exit 1 ;;
+---
+>              ifconfig ${BRNAME} destroy || exit 1 ;;
+87,88c87,88
+<             sudo kldload if_tap || exit 1
+<             sudo sysctl net.link.tap.user_open=1 ;;
+---
+>              kldload if_tap || exit 1
+>              sysctl net.link.tap.user_open=1 ;;
+98,101c98,101
+<             sudo ifconfig tap${N} create || exit 1
+<             sudo chown ${USER} /dev/tap${N} || exit 1
+<             sudo ifconfig ${BRNAME} addm tap${N} || exit 1
+<             sudo ifconfig tap${N} up || exit 1 ;;
+---
+>              ifconfig tap${N} create || exit 1
+>              chown ${USER} /dev/tap${N} || exit 1
+>              ifconfig ${BRNAME} addm tap${N} || exit 1
+>              ifconfig tap${N} up || exit 1 ;;
+104c104
+<             sudo ip tuntap add dev ${TAPNAME}${N} mode tap user ${USER} || exit 1
+---
+>              ip tuntap add dev ${TAPNAME}${N} mode tap user ${USER} || exit 1
+106c106
+<                 sudo -s sh -c "echo 1  > /proc/sys/net/ipv6/conf/${TAPNAME}${N}/disable_ipv6" || exit 1
+---
+>                  -s sh -c "echo 1  > /proc/sys/net/ipv6/conf/${TAPNAME}${N}/disable_ipv6" || exit 1
+108,109c108,109
+<             sudo ip link set dev ${TAPNAME}${N} master ${BRNAME} || exit 1
+<             sudo ip link set ${TAPNAME}${N} up || exit 1 ;;
+---
+>              ip link set dev ${TAPNAME}${N} master ${BRNAME} || exit 1
+>              ip link set ${TAPNAME}${N} up || exit 1 ;;
+111c111
+<             sudo chown ${USER} /dev/tap${N} || exit 1
+---
+>              chown ${USER} /dev/tap${N} || exit 1
+114,115c114,115
+<             sudo ifconfig ${BRNAME} addm tap${N} || exit 1
+<             sudo ifconfig tap${N} up || exit 1 ;;
+---
+>              ifconfig ${BRNAME} addm tap${N} || exit 1
+>              ifconfig tap${N} up || exit 1 ;;


### PR DESCRIPTION
Changes include a new Dockerfile that creates a Docker container with the riot-ros2 code as part of an effort to merge this work and micro-ROS project efforts.

Container includes an entrypoint that launches automatically a native talker.